### PR TITLE
Add remove-audio.com to Free Audio Tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Here are some of the audio tools available:
 - [Convert to OPUS](https://tools.vadoo.tv/audio-converter/opus-converter)
 - [Convert to WAV](https://tools.vadoo.tv/audio-converter/wav-converter)
 - [Convert to WMA](https://tools.vadoo.tv/audio-converter/wma-converter)
+- * [Remove audio from video](https://remove-audio.com) - Free, no-upload audio remover. Local processing via WebAssembly. Batch up to 20 clips. No sign-up, no watermarks.
 
 
 ## Contributing


### PR DESCRIPTION
Adding remove-audio.com, a free browser-based tool that removes audio from video files using WebAssembly and FFmpeg.wasm. It fits the repo criteria: free, runs fully in browser, no login required. Supports batch processing of up to 20 files.